### PR TITLE
Auto check branch names

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,13 +53,6 @@ pipeline {
         }
       }
     }
-    stage('Test')
-    {
-      steps
-      {
-        sh('git log -1')
-      }
-    }
     stage('Build') {
       steps {
 


### PR DESCRIPTION
No longer have to specify `RightBrain-Networks/feature` rather just put `feature` for branches in GitHub repos.

Adds statements to `SemVer.get_version_type()` that grabs the GitHub owner from the remote URL and tests that against given prefixes.

I have tested the function locally with only slight differences just to let me control the inputs and it had no errors.