### PR TITLE
Added getVersion() groovy function

### DIFF
--- a/vars/getVersion.groovy
+++ b/vars/getVersion.groovy
@@ -1,0 +1,14 @@
+#!/usr/bin/env groovy
+
+/** 
+ * Run semver_get_version to return the current version of the repository
+ *
+ * @param flags Flags or arguments to pass to semver_get_version
+ * @return "1.9.2"
+ */
+def call(flags='') {
+    def VERSION
+    VERSION = sh(returnStdout: true, script: "semver_get_version ${flags}")
+    return VERSION.trim()
+}
+


### PR DESCRIPTION
`runAutoSemver()` groovy function was failing because it called `getVersion()`. That function was added to allow for successful runs of auto-semver when using this repo as a library.