### PR TITLE
GitLab Support

### DIFF
--- a/semver/__init__.py
+++ b/semver/__init__.py
@@ -19,7 +19,7 @@ NO_GIT_FLOW = Exception('No git flow branch found')
 
 class SemVer(object):
 
-    GET_COMMIT_MESSAGE = re.compile(r"Merge (branch|pull request) '?(.+)'? (into|from) ([\w/-]+)")
+    GET_COMMIT_MESSAGE = re.compile(r"Merge (branch|pull request) '?(.+)'? (into|from) '?([\w\-]+)'?")
     # Merge pull request #1 from RightBrain-Networks/feature/PLAT-185-versioning
 
     def __init__(self,global_user=False):


### PR DESCRIPTION
- **Update regex to support**
Previously running auto-semver on GitLab merges would fail because the regular expression would not be able to properly parse the git log. This issue was solved by updating the regex to optionally check for `'` surrounding the branch name.

Old Regex: `r"Merge (branch|pull request) '?(.+)'? (into|from) ([\w/-]+)"`
New Regex: `r"Merge (branch|pull request) '?(.+)'? (into|from) '?([\w\-]+)'?"`