### PR TITLE
Fix `semver_get_version` Output

### DIFF
--- a/semver/get_version.py
+++ b/semver/get_version.py
@@ -59,7 +59,7 @@ def main():
     if args.debug:
         console_logger.setLevel(logging.DEBUG)
 
-    logger.info(get_version(args.dot))
+    print(get_version(args.dot))
 
 if __name__ == '__main__':
     try: main()

--- a/semver/tests.py
+++ b/semver/tests.py
@@ -61,6 +61,12 @@ class TestGetVersion(unittest.TestCase):
         subprocess.call(['git', 'checkout', '-b', 'test/branch'])
         branch = get_version.get_version(False)
         self.assertEqual(branch, "test/branch")
+    def test_get_version_run(self):
+        create_git_environment()
+        val = subprocess.Popen(['python', '../get_version.py', '-d'], stdout=subprocess.PIPE,
+                            stderr=open(os.devnull, 'wb'), cwd='.').stdout.read().decode('utf-8').rstrip()
+        self.assertEqual(val, "master")
+        
 
 class TestGetTagVersion(unittest.TestCase):
     def test_get_version_tag(self):

--- a/semver/tests.py
+++ b/semver/tests.py
@@ -1,7 +1,7 @@
 import unittest, os, subprocess, semver
 from semver.logger import logging, logger, console_logger
 
-from semver import get_version
+from semver import get_version, NO_MERGE_FOUND
 
 config_data = """
 [bumpversion]
@@ -36,6 +36,15 @@ class TestSemverObject(unittest.TestCase):
         semver_object.merged_branch = "patch/unittest"
         semver_object.get_version_type()
         self.assertEqual(semver_object.version_type, "patch")
+    def test_run_no_merge(self):
+        semver_object = semver.SemVer()
+        try:
+            result = semver_object.run(False)
+        except Exception as e:
+            if e == NO_MERGE_FOUND:
+                self.assertTrue(True)
+            else:
+                self.assertTrue(False)
 
 class TestGetVersion(unittest.TestCase):
     def test_get_branch_version(self):
@@ -44,19 +53,19 @@ class TestGetVersion(unittest.TestCase):
         self.assertEqual(branch, "master")
     def test_branch_dotting(self):
         create_git_environment()
-        subprocess.run(['git', 'checkout', '-b', 'test/branch'])
+        subprocess.call(['git', 'checkout', '-b', 'test/branch'])
         branch = get_version.get_version(True)
         self.assertEqual(branch, "test.branch")
     def test_branch_dotting_false(self):
         create_git_environment()
-        subprocess.run(['git', 'checkout', '-b', 'test/branch'])
+        subprocess.call(['git', 'checkout', '-b', 'test/branch'])
         branch = get_version.get_version(False)
         self.assertEqual(branch, "test/branch")
 
 class TestGetTagVersion(unittest.TestCase):
     def test_get_version_tag(self):
         create_git_environment()
-        subprocess.run(['git', 'tag', '1.0.0'])
+        subprocess.call(['git', 'tag', '1.0.0'])
         tag = get_version.get_tag_version()
         self.assertEqual(tag, "1.0.0")
     def test_default_get_version_tag(self):
@@ -65,18 +74,18 @@ class TestGetTagVersion(unittest.TestCase):
         self.assertEqual(tag, "0.0.0")
 
 def create_git_environment():
-    subprocess.run(['rm', '-rf', './.git'])
-    subprocess.run(['git', 'init'])
-    subprocess.run(['touch', 'file.txt'])
-    subprocess.run(['git', 'add', 'file.txt'])
-    subprocess.run(['git', 'commit', '-m', 'file.txt'])
-    subprocess.run(['git', 'remote', 'add', 'origin', os.getcwd()+'/.git'])
+    subprocess.call(['rm', '-rf', './.git'])
+    subprocess.call(['git', 'init'])
+    subprocess.call(['touch', 'file.txt'])
+    subprocess.call(['git', 'add', 'file.txt'])
+    subprocess.call(['git', 'commit', '-m', 'file.txt'])
+    subprocess.call(['git', 'remote', 'add', 'origin', os.getcwd()+'/.git'])
 
 if __name__ == "__main__":
     console_logger.setLevel(logging.DEBUG)
 
-    subprocess.run(['rm', '-rf', test_directory])
-    subprocess.run(['mkdir', test_directory])
+    subprocess.call(['rm', '-rf', test_directory])
+    subprocess.call(['mkdir', test_directory])
     os.chdir(test_directory)
     with open('.bumpversion.cfg', "w") as config:
         config.write(config_data)


### PR DESCRIPTION
Running semver-by-branch via the shared library was failing because `print(get_version())` was replaced with `logger.info(get_version))` which malformed the version output.

This PR fixes that issue and adds additional tests to detect issues similar to this in the future.