### PR TITLE
Use `current_version` as an input

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ tag_name = v{new_version}
 message = Bump version: {current_version} -> {new_version}
 ```
 
-The `current_version` exists to tell bumpversion what the current version is. To have auto-semver manage this value, set it to `0.0.0`. The `commit` and `tag` options determine whether to create a new Git commit and a new Git tag, respectively. The `tag_name` represents what the name of the Git tag will be, and by default is set to `{new_version}`, which will be substitued with the new version during runtime. This can be changed as desired - for example, `v{new_version}` could resolve to `v1.15.5`. The `message` option is what the message used if there is a git commit.
+The `current_version` exists to tell bumpversion what the current version is. Auto-semver uses this value as the default version if not version if found in the tags. The `commit` and `tag` options determine whether to create a new Git commit and a new Git tag, respectively. The `tag_name` represents what the name of the Git tag will be, and by default is set to `{new_version}`, which will be substitued with the new version during runtime. This can be changed as desired - for example, `v{new_version}` could resolve to `v1.15.5`. The `message` option is what the message used if there is a git commit.
 
 ### File updates
 

--- a/semver/__init__.py
+++ b/semver/__init__.py
@@ -18,9 +18,11 @@ NO_MERGE_FOUND = Exception('No merge found')
 NOT_MAIN_BRANCH = Exception('Not merging into a main branch')
 NO_GIT_FLOW = Exception('No git flow branch found')
 
+# Important regex
+GET_COMMIT_MESSAGE = re.compile(r"Merge (branch|pull request) '?([^']+)'? (into|from) (?:'(.+)'|[^\/]+\/(.+))")
+
 class SemVer(object):
 
-    GET_COMMIT_MESSAGE = re.compile(r"Merge (branch|pull request) '?(.+)'? (into|from) (?:'(.+)'|[^\/]+\/(.+))")
     # Merge pull request #1 from RightBrain-Networks/feature/PLAT-185-versioning
 
     def __init__(self,global_user=False):
@@ -52,7 +54,7 @@ class SemVer(object):
         message = str(p.stdout.read())
         branch = b.stdout.read().decode('utf-8').rstrip()
         logger.info('Main branch is ' + branch)
-        matches = self.GET_COMMIT_MESSAGE.search(message)
+        matches = GET_COMMIT_MESSAGE.search(message)
         if matches:
             if str(matches.group(4)) == branch:
                 self.merged_branch = matches.group(2)

--- a/semver/__init__.py
+++ b/semver/__init__.py
@@ -20,7 +20,7 @@ NO_GIT_FLOW = Exception('No git flow branch found')
 
 class SemVer(object):
 
-    GET_COMMIT_MESSAGE = re.compile(r"Merge (branch|pull request) '?(.+)'? (into|from) ([\w/-]+)")
+    GET_COMMIT_MESSAGE = re.compile(r"Merge (branch|pull request) '?(.+)'? (into|from) '?([\w\-]+)'?")
     # Merge pull request #1 from RightBrain-Networks/feature/PLAT-185-versioning
 
     def __init__(self,global_user=False):

--- a/semver/__init__.py
+++ b/semver/__init__.py
@@ -20,7 +20,7 @@ NO_GIT_FLOW = Exception('No git flow branch found')
 
 class SemVer(object):
 
-    GET_COMMIT_MESSAGE = re.compile(r"Merge (branch|pull request) '?(.+)'? (into|from) '?([\w\-]+)'?")
+    GET_COMMIT_MESSAGE = re.compile(r"Merge (branch|pull request) '?(.+)'? (into|from) (?:'(.+)'|[^\/]+\/(.+))")
     # Merge pull request #1 from RightBrain-Networks/feature/PLAT-185-versioning
 
     def __init__(self,global_user=False):
@@ -57,7 +57,7 @@ class SemVer(object):
             if str(matches.group(4)) == branch:
                 self.merged_branch = matches.group(2)
             else:
-                self.merged_branch = matches.group(4)
+                self.merged_branch = matches.group(5)
             self.main_branch = branch
         return bool(matches)
 

--- a/semver/get_version.py
+++ b/semver/get_version.py
@@ -20,7 +20,7 @@ def get_tag_version():
     logger.debug("Tag expression: " + str(tag_expression))
 
     # Default version is `0.0.0` or what is found in 
-    version = get_file_version()
+    version = get_file_version(config)
     
     # If a version is found in tags, use that the lastest tagged version
     tagged_versions = subprocess.Popen(['git','tag','--sort=taggerdate', '-l',tag_expression],

--- a/semver/get_version.py
+++ b/semver/get_version.py
@@ -19,13 +19,23 @@ def get_tag_version():
 
     logger.debug("Tag expression: " + str(tag_expression))
 
-    version = "0.0.0"
+    # Default version is `0.0.0` or what is found in 
+    version = get_file_version()
     
+    # If a version is found in tags, use that the lastest tagged version
     tagged_versions = subprocess.Popen(['git','tag','--sort=taggerdate', '-l',tag_expression],
         stdout=subprocess.PIPE, stderr=DEVNULL, cwd=".").stdout.read().decode('utf-8').rstrip().split('\n')
     if len(tagged_versions) > 0 and tagged_versions[-1] != "":
         version = tagged_versions[-1]
+        
     logger.debug("Tag Version: " + str(version))
+    return version
+
+def get_file_version(config):
+    version = config.get('bumpversion','current_version')
+    if not version:
+        config.set('bumpversion', 'current_version', '0.0.0')
+        version = '0.0.0'
     return version
 
 def get_version(dot=False):

--- a/vars/getVersion.groovy
+++ b/vars/getVersion.groovy
@@ -1,0 +1,14 @@
+#!/usr/bin/env groovy
+
+/** 
+ * Run semver_get_version to return the current version of the repository
+ *
+ * @param flags Flags or arguments to pass to semver_get_version
+ * @return "1.9.2"
+ */
+def call(flags='') {
+    def VERSION
+    VERSION = sh(returnStdout: true, script: "semver_get_version ${flags}")
+    return VERSION.trim()
+}
+


### PR DESCRIPTION
- Rather than using `0.0.0` for the default version, auto-semver uses `current_version` from `.bumpversion.cfg` as the default value.
- No longer need `current_version` in `.bumpverison.cfg`. If no `current_version` is found, auto-semver will set it to `0.0.0` during runtime.
- Quick regex bugfix