### PR TITLE
BUGFIX: Fixed versioning with branch name commit description

### DIFF
--- a/semver/__init__.py
+++ b/semver/__init__.py
@@ -19,7 +19,7 @@ NOT_MAIN_BRANCH = Exception('Not merging into a main branch')
 NO_GIT_FLOW = Exception('No git flow branch found')
 
 # Important regex
-GET_COMMIT_MESSAGE = re.compile(r"Merge (branch|pull request) '?([^']+)'? (into|from) (?:'(.+)'|[^\/]+\/(.+))")
+GET_COMMIT_MESSAGE = re.compile(r"Merge (branch|pull request) '?([^']+)'? (into|from) (?:'(.+)'|[^\/]+\/([^\n\\]+))")
 
 class SemVer(object):
 

--- a/semver/tests.py
+++ b/semver/tests.py
@@ -139,6 +139,13 @@ class TestGetCommitMessageRegex(unittest.TestCase):
             self.assertEqual(matches.group(2), "branch")
         else:
             self.assertTrue(False)
+    def test_branch_in_message(self):
+        matches = GET_COMMIT_MESSAGE.search(str(b'commit examplehash\nMerge: example\nAuthor: Test <test@nodomain.rightbrainnetworks.com>\nDate:   Mon Jun 15 18:15:22 2020 -0400\n\n    Merge pull request #45 from user/branch\n    \n    user/branch\n'))
+        if matches:
+            self.assertEqual(matches.group(4), None)
+            self.assertEqual(matches.group(5), "branch")
+        else:
+            self.assertTrue(False)
     def test_non_merge_message(self):
         matches = GET_COMMIT_MESSAGE.search("Example unrelated commit message that should get 0 matches")
         self.assertEqual(matches, None)


### PR DESCRIPTION
Updated regex to check single line and added test case.

The new test case `test_branch_in_message` checks the regex on a whole commit message with the branch name in the description of the commit.