### PR TITLE
Bugfix: Pipeline & Double Quotes in Commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
-library('pipeline-library')
+library('pipeline-library@bugfix/durable-task-workaround')
 
 pipeline {
   options { timestamps() }
@@ -18,7 +18,7 @@ pipeline {
     stage('Self Version') {
       steps {
         withCredentials([usernamePassword(credentialsId: env.DOCKER_CREDENTIALS, usernameVariable: 'DOCKER_USERNAME', passwordVariable: 'DOCKER_PASSWORD')]) {
-          sh("docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}")
+          sh("docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD")
         }
         runAutoSemver("rightbrainnetworks/auto-semver:${SELF_SEMVER_TAG}")
       }
@@ -59,6 +59,7 @@ pipeline {
       agent {
           docker {
               image "rightbrainnetworks/auto-semver:${env.VERSION}"
+              args "--privileged"
           }
       }
       steps
@@ -85,7 +86,7 @@ pipeline {
           // Authenticate & push to DockerHub
           withCredentials([usernamePassword(credentialsId: env.DOCKER_CREDENTIALS, usernameVariable: 'DOCKER_USERNAME', passwordVariable: 'DOCKER_PASSWORD')]) {
             sh("""
-              docker login -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+              docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD
               docker push rightbrainnetworks/auto-semver:${env.VERSION}
               """)
           }

--- a/semver/__init__.py
+++ b/semver/__init__.py
@@ -61,7 +61,7 @@ class SemVer(object):
         message = str(p.stdout.read())
         branch = b.stdout.read().decode('utf-8').rstrip()
         logger.info('Main branch is ' + branch)
-        matches = GET_COMMIT_MESSAGE.search(message)
+        matches = GET_COMMIT_MESSAGE.search(message.replace('\\n','\n').replace('\\',''))
         if matches:
             if str(matches.group(4)) == branch:
                 self.merged_branch = matches.group(2)

--- a/semver/__init__.py
+++ b/semver/__init__.py
@@ -1,6 +1,8 @@
 import argparse
 import re
 import subprocess
+import sys
+import traceback
 from enum import IntEnum
 from semver.utils import get_tag_version
 from semver.logger import logging, logger, console_logger
@@ -111,7 +113,7 @@ class SemVer(object):
             config_file = file.read()
 
         # version repo
-        logger.debug("Running bumpversion of type: " + self.version_type)
+        logger.debug("Running bumpversion of type: " + str(self.version_type.name))
         bump_version(get_tag_version(), self.version_type)
         return self
 
@@ -146,20 +148,22 @@ class SemVer(object):
         return self
 
 def main():
+    parser = argparse.ArgumentParser(description='Bump Semantic Version.')
+    parser.add_argument('-n','--no-push', help='Do not try to push', action='store_false', dest='push')
+    parser.add_argument('-g','--global-user', help='Set git user at a global level, helps in jenkins', action='store_true', dest='global_user')
+    parser.add_argument('-D', '--debug', help='Sets logging level to DEBUG', action='store_true', dest='debug', default=False)
+    args = parser.parse_args()
+
+
+    if args.debug:
+        console_logger.setLevel(logging.DEBUG)
     try:
-        parser = argparse.ArgumentParser(description='Bump Semantic Version.')
-        parser.add_argument('-n','--no-push', help='Do not try to push', action='store_false', dest='push')
-        parser.add_argument('-g','--global-user', help='Set git user at a global level, helps in jenkins', action='store_true', dest='global_user')
-        parser.add_argument('-D', '--debug', help='Sets logging level to DEBUG', action='store_true', dest='debug', default=False)
-        args = parser.parse_args()
-
-
-        if args.debug:
-            console_logger.setLevel(logging.DEBUG)
-
         SemVer(global_user=args.global_user).run(push=args.push)
     except Exception as e:
         logger.error(e)
+        if args.debug:
+            tb = sys.exc_info()[2]
+            traceback.print_tb(tb)
         if e == NO_MERGE_FOUND:
             exit(1)
         elif e == NOT_MAIN_BRANCH:

--- a/semver/tests.py
+++ b/semver/tests.py
@@ -158,6 +158,13 @@ class TestGetCommitMessageRegex(unittest.TestCase):
     def test_non_merge_message(self):
         matches = GET_COMMIT_MESSAGE.search("Example unrelated commit message that should get 0 matches")
         self.assertEqual(matches, None)
+    def test_gitlab_merge_with_double_quotes(self):
+        matches = GET_COMMIT_MESSAGE.search("Merge branch 'branch' into 'master'\n\n\"Message in quotes!\"")
+        if matches:
+            self.assertEqual(matches.group(4), "master")
+            self.assertEqual(matches.group(2), "branch")
+        else:
+            self.assertTrue(False)
 
 class TestVersionBumping(unittest.TestCase):
     def test_patch_bump(self):

--- a/vars/runAutoSemver.groovy
+++ b/vars/runAutoSemver.groovy
@@ -40,7 +40,6 @@ def call(dockerImage = "rightbrainnetworks/auto-semver:latest", debug = false) {
           break
       }
 
-      env.SEMVER_NEW_VERSION = sh(script: "grep -Po '${regex}' .bumpversion.cfg", returnStdout: true).trim()
       env.SEMVER_RESOLVED_VERSION = getVersion("-d ${args}")
 
       env.VERSION = env.SEMVER_RESOLVED_VERSION

--- a/vars/runAutoSemver.groovy
+++ b/vars/runAutoSemver.groovy
@@ -40,6 +40,7 @@ def call(dockerImage = "rightbrainnetworks/auto-semver:latest", debug = false) {
           break
       }
 
+      env.SEMVER_NEW_VERSION = sh(script: "grep -Po '${regex}' .bumpversion.cfg", returnStdout: true).trim()
       env.SEMVER_RESOLVED_VERSION = getVersion("-d ${args}")
 
       env.VERSION = env.SEMVER_RESOLVED_VERSION


### PR DESCRIPTION
1. Updates pipeline to workaround issues with running `sh` inside of a docker image (See [JENKINS-58657](https://issues.jenkins.io/browse/JENKINS-58657?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aall-tabpanel))
2. Convert line endings and `\` in commit message before regex query
3. Fix string conversion for `version_type` enum
4. Enables stack trace on `--debug`

Closes #50 